### PR TITLE
Revise TensorFlow model and pipeline

### DIFF
--- a/config/model.ini
+++ b/config/model.ini
@@ -2,24 +2,25 @@
 input_length = 28
 horizon = 7
 window_rate = 1
+encoder_units = 100
+decoder_units = 30
+
+
+[BASEMODEL]
 k_components = 0
 model_name = no_svd
-units = 150
 
 
 [SVDMODEL1]
-k_components = 15
-model_name = svd_15
-units = 150
+k_components = 10
+model_name = svd_10
 
 
 [SVDMODEL2]
-k_components = 10
-model_name = svd_10
-units = 150
+k_components = 5
+model_name = svd_5
 
 
 [SVDMODEL3]
-k_components = 5
-model_name = svd_5
-units = 150
+k_components = 2
+model_name = svd_2

--- a/src/model.py
+++ b/src/model.py
@@ -52,7 +52,7 @@ class Encoder(tf.keras.layers.Layer):
         )
         core_lstm = tf.keras.layers.LSTM(
             units=units,
-            activation='tanh',
+            activation=tf.keras.activations.swish,
             dropout=0.1,
             kernel_regularizer='l1',
             name='encoder_lstm',
@@ -112,7 +112,7 @@ class Decoder(tf.keras.layers.Layer):
 
         self.lstmcell = tf.keras.layers.LSTMCell(
             units=units,
-            activation='tanh',
+            activation=tf.keras.activations.swish,
             dropout=0.2,
             kernel_regularizer='l1',
             bias_regularizer='l2',
@@ -120,7 +120,7 @@ class Decoder(tf.keras.layers.Layer):
         )
         self.lstm = tf.keras.layers.LSTM(
             units=units,
-            activation='tanh',
+            activation=tf.keras.activations.swish,
             dropout=0.2,
             kernel_regularizer='l1',
             bias_regularizer='l2',

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -74,7 +74,9 @@ class ModelPipeline:
                 algorithm='arpack'
             )
 
-        self.scaler = MinMaxScaler()
+        self.scaler = MinMaxScaler(
+            feature_range=(0,1),
+        )
 
         self.tfmodel = model.BitcoinRNN(
             input_length=self.input_length,
@@ -212,8 +214,8 @@ class ModelPipeline:
         train_targets: list[pd.Series],
         test_features: list[pd.DataFrame],
         test_targets: list[pd.Series],
-        batch_size: Optional[int] = 96,
-        epochs: Optional[int] = 300,
+        batch_size: Optional[int] = 128,
+        epochs: Optional[int] = 100,
         new_callback_dir: Optional[bool] = True,
         **kwargs
     ):
@@ -255,7 +257,7 @@ class ModelPipeline:
         )
 
     def reload(self, checkpoint_path: Optional[str] = None, **kwargs):
-        """Reload current model weights
+        """Reload current model weights.
 
         Args:
             checkpoint_path: The checkpoint path containing model weights.

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -77,7 +77,7 @@ class ModelPipeline:
             )
 
         self.minmaxscaler = MinMaxScaler(
-            feature_range=(0,1),
+            feature_range=(0, 1),
         )
         self.normalscaler = PowerTransformer(
             method='yeo-johnson',


### PR DESCRIPTION
Changes
- Separated `units` to `encoder_units` and `decoder_units`
- Added `BASEMODEL` section dedicated to base model arguments
- Changed bi-directional LSTM state merge from `concat` to `sum`
- Minor docstring changes.

Additions:
- Added regularizers and dropouts to LSTM encoders and decoders
- Added training option to model to decide whether to include dropouts during inference
- Added `PowerTransformer` to normalize data for each feature
- Added callbacks for `NaN` loss and learning rate scheduler for consistency